### PR TITLE
Add Change Log library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,4 +76,5 @@ dependencies {
         // exclusion is not necessary, but generally a good idea.
         exclude group: 'com.google.android', module: 'support-v4'
     }
+    compile 'com.github.gabrielemariotti.changeloglib:library:1.5.2'
 }

--- a/app/src/main/java/nz/net/speakman/destinyraidtimers/ChangeLogDialog.java
+++ b/app/src/main/java/nz/net/speakman/destinyraidtimers/ChangeLogDialog.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Adam Speakman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nz.net.speakman.destinyraidtimers;
+
+import android.annotation.SuppressLint;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+import android.view.LayoutInflater;
+import android.view.View;
+
+/**
+ * Created by Adam on 15-05-17.
+ */
+public class ChangeLogDialog extends DialogFragment {
+
+    private static final String FRAGMENT_TAG = "nz.net.speakman.destinyraidtimers.ChangeLogDialog";
+
+    public static ChangeLogDialog newInstance() {
+        return new ChangeLogDialog();
+    }
+
+    public static void displayChangeLog(FragmentManager fm) {
+        FragmentTransaction ft = fm.beginTransaction();
+        Fragment prev = fm.findFragmentByTag(FRAGMENT_TAG);
+        if (prev != null) {
+            ft.remove(prev);
+        }
+        ft.addToBackStack(null);
+
+        // Create and show the dialog.
+        DialogFragment newFragment = ChangeLogDialog.newInstance();
+        newFragment.show(ft, FRAGMENT_TAG);
+    }
+
+    @SuppressLint("InflateParams")
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        View content = LayoutInflater.from(getActivity()).inflate(R.layout.dialog_changelog, null);
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.changelog_title);
+        builder.setView(content);
+        builder.setPositiveButton(android.R.string.ok,
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int id) {
+                        dialog.dismiss();
+                    }
+                });
+        return builder.create();
+    }
+}

--- a/app/src/main/java/nz/net/speakman/destinyraidtimers/MainActivity.java
+++ b/app/src/main/java/nz/net/speakman/destinyraidtimers/MainActivity.java
@@ -86,6 +86,9 @@ public class MainActivity extends BaseRaidActivity {
                 item.setChecked(!item.isChecked()); // Toggle the checkbox
                 preferences.setVibrationEnabled(item.isChecked()); // Save the new value
                 return true;
+            case R.id.action_main_change_log:
+                ChangeLogDialog.displayChangeLog(getSupportFragmentManager());
+                return true;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/res/layout/changelog_row_body.xml
+++ b/app/src/main/res/layout/changelog_row_body.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2015 Adam Speakman
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:id="@+id/chg_row"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:layout_marginLeft="12dp"
+              android:orientation="vertical" >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/listPreferredItemHeightSmall"
+        android:gravity="center_vertical"
+        android:orientation="horizontal" >
+
+
+        <!-- ChangeLog Row [Bullet Point] You have to use the id="chg_textbullet" -->
+        <TextView
+            android:id="@+id/chg_textbullet"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:layout_marginRight="2dp"
+            android:layout_marginLeft="12dp"
+            android:textAppearance="@android:style/TextAppearance.Small"
+            android:text="@string/changelog_row_bulletpoint"
+            />
+
+
+        <!-- ChangeLog Row [Text] You have to use the id="chg_text" -->
+        <TextView
+            android:id="@+id/chg_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:layout_marginLeft="12dp"
+            android:layout_marginRight="5dp"
+            android:minHeight="?android:attr/listPreferredItemHeightSmall"
+            android:textAppearance="@android:style/TextAppearance.Small"
+            />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/changelog_row_header.xml
+++ b/app/src/main/res/layout/changelog_row_header.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2015 Adam Speakman
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:id="@+id/chg_rowheader"
+              android:layout_width="match_parent"
+              android:layout_marginLeft="10dp"
+              android:layout_marginRight="10dp"
+              android:padding="10dp"
+              android:layout_height="wrap_content"
+              android:gravity="center_vertical"
+              android:orientation="vertical">
+
+
+    <!-- ChangeLog Header [Version] You have to use the id="chg_headerVersion" -->
+    <TextView
+        android:id="@+id/chg_headerVersion"
+        android:paddingLeft="8dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:text="Version 1.0 - A Guardian Rises"
+        android:textAllCaps="true"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        android:textStyle="bold"/>
+
+    <!-- ChangeLog Header [Date] You have to use the id="chg_headerDate" -->
+    <TextView
+        android:id="@+id/chg_headerDate"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        style="?android:attr/listSeparatorTextViewStyle"
+        android:text="17 May 2015"
+        android:textAllCaps="true"
+        android:textAppearance="@android:style/TextAppearance.Small"/>
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_changelog.xml
+++ b/app/src/main/res/layout/dialog_changelog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2015 Adam Speakman
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<it.gmariotti.changelibs.library.view.ChangeLogListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:chg="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    chg:rowHeaderLayoutId="@layout/changelog_row_header"
+    chg:rowLayoutId="@layout/changelog_row_body"/>

--- a/app/src/main/res/menu/menu_main_activity.xml
+++ b/app/src/main/res/menu/menu_main_activity.xml
@@ -22,6 +22,9 @@
           android:title="@string/menu_about"
           android:icon="@drawable/ic_action_about"
           app:showAsAction="never"/>
+    <item android:id="@+id/action_main_change_log"
+          android:title="@string/changelog_title"
+          app:showAsAction="never"/>
     <item android:id="@+id/action_main_settings_sound"
           android:title="Sounds"
           android:checkable="true"

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2015 Adam Speakman
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<changelog bulletedList="true">
+
+    <changelogversion versionName="1.1 - Boomer" changeDate="May 17, 2015">
+        <changelogtext>Consumable timers. Now includes a 10 minute Glimmer consumable timer and a 30 minute weapon telemetry timer.</changelogtext>
+        <changelogtext>Notifications! You now get a handy notification when a consumable timer expires.</changelogtext>
+        <changelogtext>All the animations. Aren't they beautiful?</changelogtext>
+    </changelogversion>
+
+    <changelogversion versionName="1.0 - A Guardian Rises" changeDate="Feb 22, 2015">
+        <changelogtext>Initial release.</changelogtext>
+        <changelogtext>Includes a Crota enrage and movement timers.</changelogtext>
+    </changelogversion>
+
+</changelog>

--- a/app/src/main/res/raw/licenses.html
+++ b/app/src/main/res/raw/licenses.html
@@ -316,4 +316,22 @@ limitations under the License.</pre>
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.</pre>
+
+<h3>Notices for:</h3><ul>
+    <li>changeloglib-1.5.2</li>
+</ul>
+
+<pre>Copyright 2013-2014 Gabriele Mariotti
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.</pre>
 </html>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     </string>
     <string name="app_about_licenses"><u>Open source licenses</u></string>
 
+    <string name="changelog_title">Change Log</string>
+
     <string name="consumable_timer_glimmer_finished">Glimmer consumable has run out</string>
     <string name="consumable_timer_telemetry_finished">Weapon telemetry has run out</string>
 


### PR DESCRIPTION
Add Gabriele Marriotti's [changeloglib](https://github.com/gabrielemariotti/changeloglib). Have customised it to no longer have row separators between the change items, and to spread the release version and release date across two lines. Previously it the row separators looked weird with the dark theme, and the single line wasn't enough for the longer release names ("1.0 - A Guardian Rises" definitely didn't fit with a date).
